### PR TITLE
Allowed earplugs to affect client volume (issue #105)

### DIFF
--- a/RandFramework/mainInit.sqf
+++ b/RandFramework/mainInit.sqf
@@ -192,7 +192,7 @@ if (isServer) then { //adjust weather here so intro animation is different every
 };
 
 
-ace_hearing_disableVolumeUpdate = true; 
+ace_hearing_disableVolumeUpdate = false; 
 
 
 


### PR DESCRIPTION
For some reason (either intentionally or an oversight), a script *explicitly* disabled ACE earplugs from working. Considering that ACE's primary goal is adding a realism layer, and how popular it is, it should be allowed.